### PR TITLE
debounce recalculation of linenumbers

### DIFF
--- a/lib/features/line-numbers/LineNumbers.js
+++ b/lib/features/line-numbers/LineNumbers.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var debounce = require('lodash/function/debounce');
+
 function LineNumbers(eventBus, sheet) {
 
   this._sheet = sheet;
@@ -12,10 +14,10 @@ function LineNumbers(eventBus, sheet) {
     self._utilityColumn = column;
     self.updateLineNumbers();
   });
-  var updateFct = function() {
-    self.updateLineNumbers();
-  };
-  eventBus.on([ 'cells.added', 'row.removed' ], updateFct);
+  eventBus.on([ 'cells.added', 'row.removed' ], debounce(self.updateLineNumbers.bind(self), 100, {
+    'leading': true,
+    'trailing': true
+  }));
 }
 
 

--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -12,6 +12,33 @@ var Table = require('../../lib/Table'),
 
 var OPTIONS, TABLE;
 
+// bind polyfill for PhantomJS
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function(oThis) {
+    if (typeof this !== 'function') {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+    }
+
+    var aArgs   = Array.prototype.slice.call(arguments, 1),
+        fToBind = this,
+        fNOP    = function() {},
+        fBound  = function() {
+          return fToBind.apply(this instanceof fNOP ? this : oThis,
+                 aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    if (this.prototype) {
+      // native functions don't have a prototype
+      fNOP.prototype = this.prototype;
+    }
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}
+
 
 /**
  * Bootstrap the table given the specified options and a number of locals (i.e. services)

--- a/test/spec/features/line-numbers/LineNumberSpec.js
+++ b/test/spec/features/line-numbers/LineNumberSpec.js
@@ -25,39 +25,63 @@ describe('features/utility-column', function() {
 
     it('should bootstrap diagram with component', inject(function() {}));
 
-    it('should display line numbers', inject(function(elementRegistry) {
-      var ln1 = elementRegistry.get('cell_utilityColumn_row1');
-      var ln2 = elementRegistry.get('cell_utilityColumn_row2');
+    it('should display line numbers', function(done) {
+      inject(function(elementRegistry) {
+        var ln1 = elementRegistry.get('cell_utilityColumn_row1');
+        var ln2 = elementRegistry.get('cell_utilityColumn_row2');
 
-      expect(ln1.content).to.eql(1);
-      expect(ln2.content).to.eql(2);
-    }));
+        // wait for line numbers to be updated
+        window.setTimeout(function() {
+          expect(ln1.content).to.eql(1);
+          expect(ln2.content).to.eql(2);
+          done();
+        }, 150);
+      })();
+    });
 
   });
 
 
   describe('update', function() {
-    it('should display line number for newly added row', inject(function(sheet, elementRegistry) {
-      sheet.addRow({id:'row3'});
+    it('should display line number for newly added row', function(done) {
+      inject(function(sheet, elementRegistry) {
+        sheet.addRow({id:'row3'});
 
-      var ln = elementRegistry.get('cell_utilityColumn_row3');
+        var ln = elementRegistry.get('cell_utilityColumn_row3');
 
-      expect(ln.content).to.eql(3);
-    }));
+        // wait for line numbers to be updated
+        window.setTimeout(function() {
+          expect(ln.content).to.eql(3);
+          done();
+        }, 150);
+      })();
+    });
 
-    it('should update line number when adding row in the middle', inject(function(sheet, elementRegistry) {
-      sheet.addRow({id:'row3', previous: elementRegistry.get('row1')});
+    it('should update line number when adding row in the middle', function(done) {
+      inject(function(sheet, elementRegistry) {
+        sheet.addRow({id:'row3', previous: elementRegistry.get('row1')});
 
-      expect(elementRegistry.get('cell_utilityColumn_row1').content).to.eql(1);
-      expect(elementRegistry.get('cell_utilityColumn_row3').content).to.eql(2);
-      expect(elementRegistry.get('cell_utilityColumn_row2').content).to.eql(3);
-    }));
+        // wait for line numbers to be updated
+        window.setTimeout(function() {
+          expect(elementRegistry.get('cell_utilityColumn_row1').content).to.eql(1);
+          expect(elementRegistry.get('cell_utilityColumn_row3').content).to.eql(2);
+          expect(elementRegistry.get('cell_utilityColumn_row2').content).to.eql(3);
+          done();
+        }, 150);
+      })();
+    });
 
-    it('should update line number when removing row', inject(function(sheet, elementRegistry) {
-      sheet.removeRow(elementRegistry.get('row1'));
+    it('should update line number when removing row', function(done) {
+      inject(function(sheet, elementRegistry) {
+        sheet.removeRow(elementRegistry.get('row1'));
 
-      expect(elementRegistry.get('cell_utilityColumn_row2').content).to.eql(1);
-    }));
+        // wait for line numbers to be updated
+        window.setTimeout(function() {
+          expect(elementRegistry.get('cell_utilityColumn_row2').content).to.eql(1);
+          done();
+        }, 150);
+      })();
+    });
 
   });
 


### PR DESCRIPTION
Importing large tables took longer than necessary. One major timesink is the recalculation of linenumbers whenever a new line is added. This PR debounces the recalculation of linenumbers so that they are only called when no new rows are added in quick succession. Using the `leading` option, the user also gets immediate feedback when manually adding lines.

Tests currently use real timeouts, as the lodash implementation of debounce keeps track of time in a way that can not be easily overridden by sinon fakeTimers.

Also, PhantomJS appears to not have bind on functions :/