### PR TITLE
fix(context-menu): only set range on input type text

### DIFF
--- a/src/features/context-menu/components/ContextMenuComponent.js
+++ b/src/features/context-menu/components/ContextMenuComponent.js
@@ -227,11 +227,12 @@ class ContextMenu extends Component {
     } = this.props;
 
     if (node) {
-      this.updatePosition();
 
       if (autoFocus) {
         ensureFocus(node);
       }
+
+      this.updatePosition();
     }
   }
 
@@ -396,8 +397,8 @@ function ensureFocus(el) {
     focusEl.focus();
 
     // inputs
-    if ('setSelectionRange' in focusEl) {
-      focusEl.setSelectionRange(100000, 10000);
+    if (focusEl.selectionStart && focusEl.type === 'text') {
+      focusEl.selectionStart = 100000;
     } else
 
     // content editable elements

--- a/test/spec/features/context-menu/components/ContextMenuComponentSpec.js
+++ b/test/spec/features/context-menu/components/ContextMenuComponentSpec.js
@@ -182,12 +182,54 @@ describe('features/context-menu - ContextMenuComponent', function() {
     }));
 
 
-    describe('input', function() {
+    describe('text input', function() {
 
       beforeEach(inject(function(components, eventBus, injector) {
         components.onGetComponent(
           'context-menu',
           () => () => <input type="text" className="test-input" />
+        );
+      }));
+
+
+      it('on open', inject(function(contextMenu) {
+
+        // when
+        contextMenu.open();
+
+        // then
+        var inputEl = findRenderedDOMElementWithClass(renderedTree, 'test-input');
+
+        expect(
+          document.activeElement
+        ).to.equal(inputEl);
+      }));
+
+
+      it('unless autoFocus=false', inject(function(contextMenu) {
+
+        // when
+        contextMenu.open(null, {
+          autoFocus: false
+        });
+
+        // then
+        var inputEl = findRenderedDOMElementWithClass(renderedTree, 'test-input');
+
+        expect(
+          document.activeElement
+        ).not.to.equal(inputEl);
+      }));
+
+    });
+
+
+    describe('number input', function() {
+
+      beforeEach(inject(function(components, eventBus, injector) {
+        components.onGetComponent(
+          'context-menu',
+          () => () => <input type="number" className="test-input" />
         );
       }));
 


### PR DESCRIPTION
The previous fix didn't work for input elements of type other than text. Therefore tests in dmn-js failed. This fix ensures that selection range is only set for inputs of type text.