### PR TITLE
fix(change-support): update on 'element.updateId'

### DIFF
--- a/src/core/ElementRegistry.js
+++ b/src/core/ElementRegistry.js
@@ -38,6 +38,44 @@ export default class ElementRegistry {
   clear() {
     this._elements = {};
   }
+
+  updateId(element, newId) {
+
+    this._validateId(newId);
+
+    if (typeof element === 'string') {
+      element = this.get(element);
+    }
+
+    this._eventBus.fire('element.updateId', {
+      element: element,
+      newId: newId
+    });
+
+    this.remove(element);
+
+    element.id = newId;
+
+    this.add(element);
+  }
+
+  /**
+ * Validate the suitability of the given id and signals a problem
+ * with an exception.
+ *
+ * @param {String} id
+ *
+ * @throws {Error} if id is empty or already assigned
+ */
+  _validateId(id) {
+    if (!id) {
+      throw new Error('element must have an id');
+    }
+
+    if (this._elements[id]) {
+      throw new Error('element with id ' + id + ' already added');
+    }
+  }
 }
 
 ElementRegistry.$inject = [ 'eventBus' ];

--- a/src/render/ChangeSupport.js
+++ b/src/render/ChangeSupport.js
@@ -14,13 +14,15 @@ export default class ChangeSupport {
         eventBus.once('root.add', context => {
           const newRootId = context.root.id;
 
-          this._listeners[newRootId] = this._listeners[oldRootId];
-
-          delete this._listeners[oldRootId];
+          this.updateId(oldRootId, newRootId);
         });
 
       }
 
+    });
+
+    eventBus.on('element.updateId', ({ element, newId }) => {
+      this.updateId(element.id, newId);
     });
   }
 
@@ -72,6 +74,16 @@ export default class ChangeSupport {
       }
     } else {
       this._listeners[id].length = 0;
+    }
+  }
+
+  updateId(oldId, newId) {
+    if (this._listeners[oldId]) {
+
+      this._listeners[newId] = this._listeners[oldId];
+
+      delete this._listeners[oldId];
+
     }
   }
 }

--- a/test/spec/core/ElementRegistrySpec.js
+++ b/test/spec/core/ElementRegistrySpec.js
@@ -1,5 +1,7 @@
 import { inject, bootstrap } from 'test/TestHelper';
 
+/* global sinon */
+
 
 describe('ElementRegistry', function() {
 
@@ -126,6 +128,34 @@ describe('ElementRegistry', function() {
 
     // then
     expect(elementRegistry._elements).to.eql({});
+  }));
+
+
+  it('updateId', inject(function(elementRegistry, eventBus) {
+
+    // given
+    const spy = sinon.spy();
+
+    eventBus.on('element.updateId', spy);
+
+    const element = {
+      id: 'foo'
+    };
+
+    elementRegistry.add(element);
+
+    // when
+    elementRegistry.updateId(element, 'bar');
+
+    // then
+    expect(elementRegistry._elements).to.eql({
+      bar: {
+        id: 'bar'
+      }
+    });
+
+    expect(spy).to.have.been.called;
+
   }));
 
 });

--- a/test/spec/render/ChangeSupportSpec.js
+++ b/test/spec/render/ChangeSupportSpec.js
@@ -130,4 +130,37 @@ describe('ChangeSupport', function() {
 
   });
 
+
+  describe('update ID', function() {
+
+    let spy;
+
+    const element = {
+      id: 'foo'
+    };
+
+    beforeEach(inject(function(changeSupport, elementRegistry) {
+      spy = sinon.spy();
+
+      changeSupport.onElementsChanged(element.id, spy);
+
+      elementRegistry.updateId(element, 'bar');
+    }));
+
+
+    it('should update on elements change after updating ID', inject(
+      function(eventBus, changeSupport) {
+
+        // when
+        eventBus.fire('elements.changed', {
+          elements: [ element ]
+        });
+
+        // then
+        expect(spy).to.have.been.called;
+      })
+    );
+
+  });
+
 });


### PR DESCRIPTION
* add `updateId` method to ElementRegistry
* ChangeSupport listens for `element.updateId` and updates accordingly

Closes #19 
