### PR TITLE
chore(project): use source maps in dev

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -85,7 +85,8 @@ module.exports = function(karma) {
           'node_modules',
           __dirname
         ]
-      }
+      },
+      devtool: 'eval-source-map'
     }
   });
 


### PR DESCRIPTION
This adds source maps to the dev mode. It does not affect the production
code, but makes debugging the tests much easier. The most demanding
devtool was chosen because it's the most useful and still does not seem
to reduce the performance in any significant way.