### PR TITLE
fix(context-menu): auto-close only when clicked outside of menu

### DIFF
--- a/src/features/context-menu/components/ContextMenuComponent.js
+++ b/src/features/context-menu/components/ContextMenuComponent.js
@@ -210,13 +210,13 @@ class ContextMenu extends Component {
   componentDidMount() {
     document.addEventListener('focusin', this.onFocusChanged);
     document.addEventListener('keydown', this.onGlobalKey);
-    document.addEventListener('click', this.onGlobalClick);
+    document.addEventListener('mousedown', this.onGlobalClick);
   }
 
   componentWillUnmount() {
     document.removeEventListener('focusin', this.onFocusChanged);
     document.removeEventListener('keydown', this.onGlobalKey);
-    document.removeEventListener('click', this.onGlobalClick);
+    document.removeEventListener('mousedown', this.onGlobalClick);
   }
 
   setNode = (node) => {

--- a/src/features/context-menu/components/ContextMenuComponent.js
+++ b/src/features/context-menu/components/ContextMenuComponent.js
@@ -178,9 +178,9 @@ class ContextMenu extends Component {
   }
 
   /**
-   * Handle global (window) click event.
+   * Handle global (window) mousedown event.
    */
-  onGlobalClick = (event) => {
+  onGlobalMouseDown = (event) => {
     this.checkClose(event.target);
   }
 
@@ -210,13 +210,13 @@ class ContextMenu extends Component {
   componentDidMount() {
     document.addEventListener('focusin', this.onFocusChanged);
     document.addEventListener('keydown', this.onGlobalKey);
-    document.addEventListener('mousedown', this.onGlobalClick);
+    document.addEventListener('mousedown', this.onGlobalMouseDown);
   }
 
   componentWillUnmount() {
     document.removeEventListener('focusin', this.onFocusChanged);
     document.removeEventListener('keydown', this.onGlobalKey);
-    document.removeEventListener('mousedown', this.onGlobalClick);
+    document.removeEventListener('mousedown', this.onGlobalMouseDown);
   }
 
   setNode = (node) => {

--- a/test/spec/features/context-menu/components/ContextMenuComponentSpec.js
+++ b/test/spec/features/context-menu/components/ContextMenuComponentSpec.js
@@ -126,6 +126,41 @@ describe('features/context-menu - ContextMenuComponent', function() {
     }));
 
 
+    it('on mousedown outside of context menu', inject(function(contextMenu) {
+
+      // given
+      contextMenu.open();
+
+      // when
+      triggerMouseEvent(document.body, 'mousedown');
+
+      // then
+      expect(
+        findRenderedDOMElementWithClass(renderedTree, 'context-menu')
+      ).not.to.exist;
+    }));
+
+
+    it('unless click was started inside context menu', inject(
+      function(contextMenu) {
+
+        // given
+        contextMenu.open();
+        const element = findRenderedDOMElementWithClass(renderedTree, 'context-menu');
+
+        // when
+        triggerMouseEvent(element, 'mousedown');
+        triggerMouseEvent(document.body, 'mouseup');
+        triggerMouseEvent(document.body, 'click');
+
+        // then
+        expect(
+          findRenderedDOMElementWithClass(renderedTree, 'context-menu')
+        ).to.exist;
+      })
+    );
+
+
     describe('unless autoClose=false', function() {
 
       it('on global click', inject(function(contextMenu) {
@@ -394,6 +429,8 @@ describe('features/context-menu - ContextMenuComponent', function() {
 // helpers /////////////////////
 
 function triggerClick(el, clientX, clientY, ctrlKey) {
+  triggerMouseEvent(el, 'mousedown', clientX, clientY, ctrlKey);
+  triggerMouseEvent(el, 'mouseup', clientX, clientY, ctrlKey);
   triggerMouseEvent(el, 'click', clientX, clientY, ctrlKey);
 }
 


### PR DESCRIPTION
This prevents context menu from closing when the click action was
started inside the context menu but finished outside of it.

Previously, the component listened to global `click` events
and based on this decided whether to auto-close or not. However,
when the `mousedown` and `mouseup` events target different elements,
the `click` event targets their closest common ancestor. In that
case, the target will always be outside of the context menu,
thus triggering the auto-close action.

This commits replaces the `click` listener with a `mousedown`
event listener. Therefore, the context menu will never be closed
in case of a click action started within the context menu.
Still, the close action will be triggered in all situations
covered by the previous behaviour as `click` event is always
preceded by `mousedown` (cf. https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).

Related to https://github.com/camunda/camunda-modeler/issues/1225