### PR TITLE
Use LTS node version for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 'node'
+node_js: 'lts/*'
 
 addons:
   firefox: 'latest-esr'


### PR DESCRIPTION
Let's use LTS version of Node.js instead of the latest which [occurs to be not that stable](https://travis-ci.org/bpmn-io/table-js/builds/601816336).