### PR TITLE
Allow to open context menu at exact position

### DIFF
--- a/src/features/context-menu/components/ContextMenuComponent.js
+++ b/src/features/context-menu/components/ContextMenuComponent.js
@@ -271,68 +271,52 @@ class ContextMenu extends Component {
 
     const style = {};
 
-    if (position.x + (position.width / 2) > containerBounds.width / 2) {
-      let left = position.x
+    let left, top;
+
+    if (
+      !position.exact && position.x + (position.width / 2) > containerBounds.width / 2
+    ) {
+      left = position.x
         - containerBounds.left
         - bounds.width
         + offset.x
         + scrollLeft;
-
-      left = clampNumber(
-        left,
-        0 + scrollLeft,
-        containerBounds.width - bounds.width + scrollLeft
-      );
-
-      style.left = left + 'px';
     } else {
-      let left = window.scrollX
+      left = window.scrollX
         - containerBounds.left
         + position.x
         + position.width
         - offset.x
         + scrollLeft;
-
-      left = clampNumber(
-        left,
-        0 + scrollLeft,
-        containerBounds.width - bounds.width + scrollLeft
-      );
-
-      style.left = left + 'px';
     }
+    left = position.exact ? left : clampNumber(
+      left,
+      0 + scrollLeft,
+      containerBounds.width - bounds.width + scrollLeft
+    );
+    style.left = left + 'px';
 
-    let top;
-
-    if (position.y + (position.height / 2) > containerBounds.height / 2) {
+    if (
+      !position.exact && position.y + (position.height / 2) > containerBounds.height / 2
+    ) {
       top = position.y
         - containerBounds.top
         - bounds.height
         + offset.y
         + scrollTop;
-
-      top = clampNumber(
-        top,
-        0 + scrollTop,
-        containerBounds.height - bounds.height + scrollTop
-      );
-
-      style.top = top + 'px';
     } else {
       top = window.scrollY
         - containerBounds.top
         + position.y
         - offset.y
         + scrollTop;
-
-      top = clampNumber(
-        top,
-        0 + scrollTop,
-        containerBounds.height - bounds.height + scrollTop
-      );
-
-      style.top = top + 'px';
     }
+    top = position.exact ? top : clampNumber(
+      top,
+      0 + scrollTop,
+      containerBounds.height - bounds.height + scrollTop
+    );
+    style.top = top + 'px';
 
     // ensure context menu will always be accessible
     style.overflowY = 'auto';

--- a/test/spec/features/context-menu/components/ContextMenuComponentSpec.js
+++ b/test/spec/features/context-menu/components/ContextMenuComponentSpec.js
@@ -15,6 +15,7 @@ import { inject, bootstrap } from 'test/TestHelper';
 import ContextMenuModule from 'src/features/context-menu';
 import ContextMenuComponent
   from 'src/features/context-menu/components/ContextMenuComponent';
+import { expect } from 'chai';
 
 
 function withContext(WithoutContext, context) {
@@ -376,6 +377,39 @@ describe('features/context-menu - ContextMenuComponent', function() {
       expect(node.style.left).to.not.equal('');
     }
   ));
+
+
+  it('should render context menu at exact position', inject(
+    function(components, contextMenu, eventBus, injector) {
+
+      // given
+      const WithContext = withContext(ContextMenuComponent, {
+        injector,
+        eventBus
+      });
+
+      const renderedTree = renderIntoDocument(<WithContext />);
+
+      components.onGetComponent('context-menu', () => () => <div></div>);
+
+      // when
+      container.scrollTop = 100;
+      contextMenu.open({
+        x: 100,
+        y: 0,
+        exact: true
+      });
+
+      // then
+      const node = findRenderedDOMElementWithClass(renderedTree, 'context-menu');
+
+      expect(node).to.exist;
+      expect(node.style.top).to.not.equal('');
+      expect(node.style.left).to.not.equal('');
+      expect(/^-/.test(node.style.top), 'style.top should be negative').to.be.true;
+    }
+  ));
+
 
   // skip on Firefox due to inconsistent focus handling,
   // cf. https://github.com/bpmn-io/table-js/pull/25 and linked sources


### PR DESCRIPTION
To use the feature, pass `exact=true` in context menu position.

Closes #31